### PR TITLE
feat: add vehicles list endpoint

### DIFF
--- a/src/controllers/VehicleController.ts
+++ b/src/controllers/VehicleController.ts
@@ -25,6 +25,18 @@ class VehicleController {
 			return res.status(500).json({ message: "Vehicle creation failed" });
 		}
 	}
+
+	static async list(req: Request, res: Response): Promise<Response> {
+		try {
+			const userId = (req as any).user.sub as string;
+			const vehicles = await VehicleService.list(userId);
+			new Succ(200, "Fetched vehicles", vehicles);
+			return res.status(200).json(vehicles);
+		} catch (err: any) {
+			new Err(500, "Vehicle fetch failed", err);
+			return res.status(500).json({ message: "Vehicle fetch failed" });
+		}
+	}
 }
 
 export default VehicleController;

--- a/src/routes/VehicleRoutes.ts
+++ b/src/routes/VehicleRoutes.ts
@@ -4,6 +4,9 @@ import { requireAuth } from "../middlewares/AuthMiddleware";
 
 const router = Router();
 
+// GET /api/v1/vehicles
+router.get("/", requireAuth, VehicleController.list);
+
 // POST /api/v1/vehicles
 router.post("/", requireAuth, VehicleController.create);
 

--- a/src/services/VehicleService.ts
+++ b/src/services/VehicleService.ts
@@ -63,6 +63,30 @@ class VehicleService {
 			throw err;
 		}
 	}
+
+	/**
+	 * List all vehicles for the given user.
+	 */
+	static async list(userId: string): Promise<VehiclePayload[]> {
+		try {
+			const vehicles = await Vehicle.find({ userId });
+			const payload = vehicles.map((v) => ({
+				id: v.id,
+				userId: v.userId,
+				name: v.name,
+				registrationPlate: v.registrationPlate,
+				fuelType: v.fuelType,
+				note: v.note,
+				isDefault: v.isDefault,
+				createdAt: v.createdAt,
+			}));
+			new Succ(200, "Fetched vehicles", payload);
+			return payload;
+		} catch (err: any) {
+			new Err(500, "Vehicle fetch failed", err);
+			throw err;
+		}
+	}
 }
 
 export default VehicleService;

--- a/tests/VehicleController.spec.ts
+++ b/tests/VehicleController.spec.ts
@@ -65,3 +65,41 @@ describe("VehicleController – POST /api/v1/vehicles", () => {
 		expect(res.body).toEqual(returned);
 	});
 });
+
+describe("VehicleController – GET /api/v1/vehicles", () => {
+	const userId = "user123";
+	const token = jwt.sign({ sub: userId, email: "x@example.com" }, env.JWT_SECRET, {
+		expiresIn: "1h",
+	});
+
+	const returned = [
+		{
+			id: "veh1",
+			userId,
+			name: "Car 1",
+			registrationPlate: "AAA-111",
+			fuelType: "petrol",
+			note: "n1",
+			isDefault: true,
+			createdAt: new Date().toISOString(),
+		},
+	];
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it("returns 401 if not authenticated", async () => {
+		const res = await request(app).get("/api/v1/vehicles");
+		expect(res.status).toBe(401);
+		expect(res.body).toMatchObject({ message: expect.stringContaining("Unauthorized") });
+	});
+
+	it("calls VehicleService.list and returns 200 + payload", async () => {
+		const spy = jest.spyOn(VehicleService, "list").mockResolvedValue(returned as any);
+		const res = await request(app).get("/api/v1/vehicles").set("Authorization", `Bearer ${token}`);
+		expect(spy).toHaveBeenCalledWith(userId);
+		expect(res.status).toBe(200);
+		expect(res.body).toEqual(returned);
+	});
+});

--- a/tests/VehicleService.spec.ts
+++ b/tests/VehicleService.spec.ts
@@ -52,4 +52,33 @@ describe("VehicleService", () => {
 			await expect(VehicleService.create(dto)).rejects.toThrow("DB failure");
 		});
 	});
+
+	describe("list()", () => {
+		it("returns vehicles for the user", async () => {
+			const docs = [
+				{
+					id: "veh1",
+					userId: dto.userId,
+					name: "Car 1",
+					registrationPlate: "ABC-123",
+					fuelType: "petrol",
+					note: "note",
+					isDefault: false,
+					createdAt: new Date(),
+				},
+			];
+			const findSpy = jest.spyOn(Vehicle, "find").mockResolvedValue(docs as any);
+
+			const res = await VehicleService.list(dto.userId);
+			expect(findSpy).toHaveBeenCalledWith({ userId: dto.userId });
+			expect(res).toEqual(docs);
+		});
+
+		it("throws if the find operation fails", async () => {
+			const dbError = new Error("DB failure");
+			jest.spyOn(Vehicle, "find").mockRejectedValue(dbError);
+
+			await expect(VehicleService.list(dto.userId)).rejects.toThrow("DB failure");
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- add GET /api/v1/vehicles to list user's vehicles
- cover vehicles listing with service and controller tests

## Testing
- `npm test`
- `npm run lint` *(fails: useNodejsImportProtocol, noStaticOnlyClass, noExplicitAny, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68af49a768148325bb767df212ae96d5