### PR TITLE
feat: add refuel CRUD operations

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,321 @@
+openapi: 3.0.3
+info:
+  title: Fuelstats API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3000
+paths:
+  '/':
+    get:
+      summary: Root endpoint
+      responses:
+        '200':
+          description: OK
+  '/api/v1/auth/signup':
+    post:
+      summary: Register a new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewUser'
+      responses:
+        '201':
+          description: User created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+  '/api/v1/auth/signin':
+    post:
+      summary: Authenticate a user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: Authentication token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthToken'
+  '/api/v1/user/me':
+    get:
+      summary: Get current user
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Current user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+  '/api/v1/vehicles':
+    get:
+      summary: List vehicles
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Array of vehicles
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Vehicle'
+    post:
+      summary: Create vehicle
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewVehicle'
+      responses:
+        '201':
+          description: Created vehicle
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vehicle'
+  '/api/v1/vehicles/{id}':
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get vehicle by ID
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Vehicle
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vehicle'
+    put:
+      summary: Update vehicle
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewVehicle'
+      responses:
+        '200':
+          description: Updated vehicle
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vehicle'
+    delete:
+      summary: Delete vehicle
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Deleted
+  '/api/v1/refuels':
+    get:
+      summary: List refuel records
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Array of refuels
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Refuel'
+    post:
+      summary: Create refuel record
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewRefuel'
+      responses:
+        '201':
+          description: Created refuel
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Refuel'
+  '/api/v1/refuels/{id}':
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get refuel by ID
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Refuel
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Refuel'
+    put:
+      summary: Update refuel
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewRefuel'
+      responses:
+        '200':
+          description: Updated refuel
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Refuel'
+    delete:
+      summary: Delete refuel
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Deleted
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+          format: email
+        username:
+          type: string
+    NewUser:
+      type: object
+      required: [email, password]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+        username:
+          type: string
+    LoginRequest:
+      type: object
+      required: [email, password]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+    AuthToken:
+      type: object
+      properties:
+        token:
+          type: string
+    Vehicle:
+      type: object
+      properties:
+        id:
+          type: string
+        userId:
+          type: string
+        name:
+          type: string
+        registrationPlate:
+          type: string
+        fuelType:
+          type: string
+        note:
+          type: string
+        isDefault:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+    NewVehicle:
+      type: object
+      required: [name, registrationPlate, fuelType]
+      properties:
+        name:
+          type: string
+        registrationPlate:
+          type: string
+        fuelType:
+          type: string
+        note:
+          type: string
+        isDefault:
+          type: boolean
+    Refuel:
+      type: object
+      properties:
+        id:
+          type: string
+        userId:
+          type: string
+        vehicleId:
+          type: string
+        fuelType:
+          type: string
+        note:
+          type: string
+        liters:
+          type: number
+        pricePerLiter:
+          type: number
+        totalPrice:
+          type: number
+        mileage:
+          type: number
+        createdAt:
+          type: string
+          format: date-time
+    NewRefuel:
+      type: object
+      required: [vehicleId, fuelType, liters, pricePerLiter, totalPrice, mileage]
+      properties:
+        vehicleId:
+          type: string
+        fuelType:
+          type: string
+        note:
+          type: string
+        liters:
+          type: number
+        pricePerLiter:
+          type: number
+        totalPrice:
+          type: number
+        mileage:
+          type: number

--- a/src/controllers/RefuelController.ts
+++ b/src/controllers/RefuelController.ts
@@ -1,0 +1,101 @@
+import { Request, Response } from "express";
+import RefuelService from "../services/RefuelService";
+import { Err, Succ } from "../services/globalService";
+
+class RefuelController {
+        static async create(req: Request, res: Response): Promise<Response> {
+                try {
+                        const userId = (req as any).user.sub as string;
+                        const dto = {
+                                userId,
+                                vehicleId: req.body.vehicleId,
+                                fuelType: req.body.fuelType,
+                                note: req.body.note,
+                                liters: req.body.liters,
+                                pricePerLiter: req.body.pricePerLiter,
+                                totalPrice: req.body.totalPrice,
+                                mileage: req.body.mileage,
+                        };
+                        const refuel = await RefuelService.create(dto);
+                        new Succ(201, "Refuel created", refuel);
+                        return res.status(201).json(refuel);
+                } catch (err: any) {
+                        new Err(500, "Refuel creation failed", err);
+                        return res.status(500).json({ message: "Refuel creation failed" });
+                }
+        }
+
+        static async show(req: Request, res: Response): Promise<Response> {
+                try {
+                        const userId = (req as any).user.sub as string;
+                        const id = req.params.id;
+                        const refuel = await RefuelService.getById(id, userId);
+                        if (!refuel) {
+                                new Err(404, "Refuel not found", { id, userId });
+                                return res.status(404).json({ message: "Refuel not found" });
+                        }
+                        new Succ(200, "Refuel fetched", refuel);
+                        return res.status(200).json(refuel);
+                } catch (err: any) {
+                        new Err(500, "Refuel fetch failed", err);
+                        return res.status(500).json({ message: "Refuel fetch failed" });
+                }
+        }
+
+        static async list(req: Request, res: Response): Promise<Response> {
+                try {
+                        const userId = (req as any).user.sub as string;
+                        const refuels = await RefuelService.list(userId);
+                        new Succ(200, "Fetched refuels", refuels);
+                        return res.status(200).json(refuels);
+                } catch (err: any) {
+                        new Err(500, "Refuel fetch failed", err);
+                        return res.status(500).json({ message: "Refuel fetch failed" });
+                }
+        }
+
+        static async update(req: Request, res: Response): Promise<Response> {
+                try {
+                        const userId = (req as any).user.sub as string;
+                        const id = req.params.id;
+                        const payload = {
+                                vehicleId: req.body.vehicleId,
+                                fuelType: req.body.fuelType,
+                                note: req.body.note,
+                                liters: req.body.liters,
+                                pricePerLiter: req.body.pricePerLiter,
+                                totalPrice: req.body.totalPrice,
+                                mileage: req.body.mileage,
+                        };
+                        const refuel = await RefuelService.update(id, userId, payload);
+                        new Succ(200, "Refuel updated", refuel);
+                        return res.status(200).json(refuel);
+                } catch (err: any) {
+                        if (err.message === "Refuel not found") {
+                                new Err(404, "Refuel not found", err);
+                                return res.status(404).json({ message: "Refuel not found" });
+                        }
+                        new Err(500, "Refuel update failed", err);
+                        return res.status(500).json({ message: "Refuel update failed" });
+                }
+        }
+
+        static async remove(req: Request, res: Response): Promise<Response> {
+                try {
+                        const userId = (req as any).user.sub as string;
+                        const id = req.params.id;
+                        await RefuelService.remove(id, userId);
+                        new Succ(204, "Refuel deleted", { id });
+                        return res.status(204).send();
+                } catch (err: any) {
+                        if (err.message === "Refuel not found") {
+                                new Err(404, "Refuel not found", err);
+                                return res.status(404).json({ message: "Refuel not found" });
+                        }
+                        new Err(500, "Refuel deletion failed", err);
+                        return res.status(500).json({ message: "Refuel deletion failed" });
+                }
+        }
+}
+
+export default RefuelController;

--- a/src/models/Refuel.ts
+++ b/src/models/Refuel.ts
@@ -1,0 +1,57 @@
+import { Schema, model, Document } from "mongoose";
+
+export interface IRefuel extends Document {
+        userId: string;
+        vehicleId: string;
+        fuelType: string;
+        note?: string;
+        liters: number;
+        pricePerLiter: number;
+        totalPrice: number;
+        mileage: number;
+        createdAt: Date;
+}
+
+const refuelSchema = new Schema<IRefuel>(
+        {
+                userId: {
+                        type: String,
+                        required: true,
+                        index: true,
+                },
+                vehicleId: {
+                        type: String,
+                        required: true,
+                        index: true,
+                },
+                fuelType: {
+                        type: String,
+                        required: true,
+                },
+                note: {
+                        type: String,
+                },
+                liters: {
+                        type: Number,
+                        required: true,
+                },
+                pricePerLiter: {
+                        type: Number,
+                        required: true,
+                },
+                totalPrice: {
+                        type: Number,
+                        required: true,
+                },
+                mileage: {
+                        type: Number,
+                        required: true,
+                },
+        },
+        {
+                timestamps: { createdAt: true, updatedAt: false },
+        },
+);
+
+const Refuel = model<IRefuel>("Refuel", refuelSchema);
+export default Refuel;

--- a/src/routes/RefuelRoutes.ts
+++ b/src/routes/RefuelRoutes.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import RefuelController from "../controllers/RefuelController";
+import { requireAuth } from "../middlewares/AuthMiddleware";
+
+const router = Router();
+
+router.get("/", requireAuth, RefuelController.list);
+router.post("/", requireAuth, RefuelController.create);
+router.get("/:id", requireAuth, RefuelController.show);
+router.put("/:id", requireAuth, RefuelController.update);
+router.delete("/:id", requireAuth, RefuelController.remove);
+
+export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,6 +3,7 @@ import { router as rootRoutes } from "./rootRoutes";
 import AuthRoutes from "./AuthRoutes";
 import UserRoutes from "./UserRoutes";
 import VehicleRoutes from "./VehicleRoutes";
+import RefuelRoutes from "./RefuelRoutes";
 
 export const router = Router();
 
@@ -10,6 +11,7 @@ router.use(rootRoutes);
 router.use("/api/v1/auth", AuthRoutes);
 router.use("/api/v1/user", UserRoutes);
 router.use("/api/v1/vehicles", VehicleRoutes);
+router.use("/api/v1/refuels", RefuelRoutes);
 
 // 404
 router.use((req: Request, res: Response) => {

--- a/src/services/RefuelService.ts
+++ b/src/services/RefuelService.ts
@@ -1,0 +1,169 @@
+import Refuel, { IRefuel } from "../models/Refuel";
+import { Err, Succ } from "./globalService";
+
+export interface CreateRefuelDTO {
+        userId: string;
+        vehicleId: string;
+        fuelType: string;
+        note?: string;
+        liters: number;
+        pricePerLiter: number;
+        totalPrice: number;
+        mileage: number;
+}
+
+export interface RefuelPayload {
+        id: string;
+        userId: string;
+        vehicleId: string;
+        fuelType: string;
+        note?: string;
+        liters: number;
+        pricePerLiter: number;
+        totalPrice: number;
+        mileage: number;
+        createdAt: Date;
+}
+
+class RefuelService {
+        static async create(data: CreateRefuelDTO): Promise<RefuelPayload> {
+                try {
+                        const refuel = new Refuel({
+                                userId: data.userId,
+                                vehicleId: data.vehicleId,
+                                fuelType: data.fuelType,
+                                note: data.note,
+                                liters: data.liters,
+                                pricePerLiter: data.pricePerLiter,
+                                totalPrice: data.totalPrice,
+                                mileage: data.mileage,
+                        } as Partial<IRefuel>);
+
+                        await refuel.save();
+
+                        const payload: RefuelPayload = {
+                                id: refuel.id,
+                                userId: refuel.userId,
+                                vehicleId: refuel.vehicleId,
+                                fuelType: refuel.fuelType,
+                                note: refuel.note,
+                                liters: refuel.liters,
+                                pricePerLiter: refuel.pricePerLiter,
+                                totalPrice: refuel.totalPrice,
+                                mileage: refuel.mileage,
+                                createdAt: refuel.createdAt,
+                        };
+
+                        new Succ(201, "Refuel created", payload);
+                        return payload;
+                } catch (err: any) {
+                        new Err(500, "Refuel creation failed", err);
+                        throw err;
+                }
+        }
+
+        static async getById(id: string, userId: string): Promise<RefuelPayload | null> {
+                try {
+                        const refuel = await Refuel.findOne({ _id: id, userId });
+                        if (!refuel) {
+                                new Err(404, "Refuel not found", { id, userId });
+                                return null;
+                        }
+
+                        const payload: RefuelPayload = {
+                                id: refuel.id,
+                                userId: refuel.userId,
+                                vehicleId: refuel.vehicleId,
+                                fuelType: refuel.fuelType,
+                                note: refuel.note,
+                                liters: refuel.liters,
+                                pricePerLiter: refuel.pricePerLiter,
+                                totalPrice: refuel.totalPrice,
+                                mileage: refuel.mileage,
+                                createdAt: refuel.createdAt,
+                        };
+
+                        new Succ(200, "Refuel fetched", payload);
+                        return payload;
+                } catch (err: any) {
+                        new Err(500, "Refuel fetch failed", err);
+                        throw err;
+                }
+        }
+
+        static async list(userId: string): Promise<RefuelPayload[]> {
+                try {
+                        const refuels = await Refuel.find({ userId });
+                        const payload = refuels.map((r) => ({
+                                id: r.id,
+                                userId: r.userId,
+                                vehicleId: r.vehicleId,
+                                fuelType: r.fuelType,
+                                note: r.note,
+                                liters: r.liters,
+                                pricePerLiter: r.pricePerLiter,
+                                totalPrice: r.totalPrice,
+                                mileage: r.mileage,
+                                createdAt: r.createdAt,
+                        }));
+                        new Succ(200, "Fetched refuels", payload);
+                        return payload;
+                } catch (err: any) {
+                        new Err(500, "Refuel fetch failed", err);
+                        throw err;
+                }
+        }
+
+        static async update(
+                id: string,
+                userId: string,
+                payload: Partial<Pick<IRefuel, "vehicleId" | "fuelType" | "note" | "liters" | "pricePerLiter" | "totalPrice" | "mileage">>,
+        ): Promise<RefuelPayload> {
+                try {
+                        const updated = await Refuel.findOneAndUpdate({ _id: id, userId }, payload, { new: true });
+                        if (!updated) {
+                                new Err(404, "Refuel not found");
+                                throw new Error("Refuel not found");
+                        }
+                        const result: RefuelPayload = {
+                                id: updated.id,
+                                userId: updated.userId,
+                                vehicleId: updated.vehicleId,
+                                fuelType: updated.fuelType,
+                                note: updated.note,
+                                liters: updated.liters,
+                                pricePerLiter: updated.pricePerLiter,
+                                totalPrice: updated.totalPrice,
+                                mileage: updated.mileage,
+                                createdAt: updated.createdAt,
+                        };
+                        new Succ(200, "Refuel updated", result);
+                        return result;
+                } catch (err: any) {
+                        if (err.message === "Refuel not found") {
+                                throw err;
+                        }
+                        new Err(500, "Refuel update failed", err);
+                        throw err;
+                }
+        }
+
+        static async remove(id: string, userId: string): Promise<void> {
+                try {
+                        const deleted = await Refuel.findOneAndDelete({ _id: id, userId });
+                        if (!deleted) {
+                                new Err(404, `Refuel not found or not owned by user`, { id, userId });
+                                throw new Error("Refuel not found");
+                        }
+                        new Succ(200, "Refuel removed", { id });
+                } catch (err: any) {
+                        if (err.message === "Refuel not found") {
+                                throw err;
+                        }
+                        new Err(500, "Refuel deletion failed", err);
+                        throw err;
+                }
+        }
+}
+
+export default RefuelService;

--- a/tests/RefuelController.spec.ts
+++ b/tests/RefuelController.spec.ts
@@ -1,0 +1,254 @@
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { app } from "../src/app";
+import RefuelService from "../src/services/RefuelService";
+import env from "../src/config/environment";
+
+describe("RefuelController – POST /api/v1/refuels", () => {
+        const userId = "user123";
+        const token = jwt.sign({ sub: userId, email: "x@example.com" }, env.JWT_SECRET, { expiresIn: "1h" });
+
+        const createDto = {
+                userId,
+                vehicleId: "veh1",
+                fuelType: "petrol",
+                note: "note",
+                liters: 10,
+                pricePerLiter: 1.2,
+                totalPrice: 12,
+                mileage: 1000,
+        };
+
+        const returned = {
+                id: "ref1",
+                userId,
+                vehicleId: createDto.vehicleId,
+                fuelType: createDto.fuelType,
+                note: createDto.note,
+                liters: createDto.liters,
+                pricePerLiter: createDto.pricePerLiter,
+                totalPrice: createDto.totalPrice,
+                mileage: createDto.mileage,
+                createdAt: new Date().toISOString(),
+        };
+
+        afterEach(() => {
+                jest.resetAllMocks();
+        });
+
+        it("returns 401 if not authenticated", async () => {
+                const res = await request(app).post("/api/v1/refuels").send(createDto);
+                expect(res.status).toBe(401);
+                expect(res.body).toMatchObject({ message: expect.stringContaining("Unauthorized") });
+        });
+
+        it("calls RefuelService.create and returns 201 + payload", async () => {
+                const spy = jest.spyOn(RefuelService, "create").mockResolvedValue(returned as any);
+
+                const res = await request(app)
+                        .post("/api/v1/refuels")
+                        .set("Authorization", `Bearer ${token}`)
+                        .send({
+                                vehicleId: createDto.vehicleId,
+                                fuelType: createDto.fuelType,
+                                note: createDto.note,
+                                liters: createDto.liters,
+                                pricePerLiter: createDto.pricePerLiter,
+                                totalPrice: createDto.totalPrice,
+                                mileage: createDto.mileage,
+                        });
+
+                expect(spy).toHaveBeenCalledWith({
+                        userId,
+                        vehicleId: createDto.vehicleId,
+                        fuelType: createDto.fuelType,
+                        note: createDto.note,
+                        liters: createDto.liters,
+                        pricePerLiter: createDto.pricePerLiter,
+                        totalPrice: createDto.totalPrice,
+                        mileage: createDto.mileage,
+                });
+                expect(res.status).toBe(201);
+                expect(res.body).toEqual(returned);
+        });
+});
+
+describe("RefuelController – PUT /api/v1/refuels/:id", () => {
+        const userId = "user123";
+        const refuelId = "ref789";
+        const token = jwt.sign({ sub: userId, email: "x@example.com" }, env.JWT_SECRET, { expiresIn: "1h" });
+
+        const updatePayload = { liters: 20 };
+        const returned = {
+                id: refuelId,
+                userId,
+                vehicleId: "veh1",
+                fuelType: "petrol",
+                note: "note",
+                liters: updatePayload.liters,
+                pricePerLiter: 1.2,
+                totalPrice: 24,
+                mileage: 1100,
+                createdAt: new Date().toISOString(),
+        };
+
+        afterEach(() => {
+                jest.resetAllMocks();
+        });
+
+        it("returns 401 if not authenticated", async () => {
+                const res = await request(app).put(`/api/v1/refuels/${refuelId}`).send(updatePayload);
+                expect(res.status).toBe(401);
+                expect(res.body).toMatchObject({ message: expect.stringContaining("Unauthorized") });
+        });
+
+        it("calls RefuelService.update and returns 200 + payload", async () => {
+                const spy = jest.spyOn(RefuelService, "update").mockResolvedValue(returned as any);
+
+                const res = await request(app)
+                        .put(`/api/v1/refuels/${refuelId}`)
+                        .set("Authorization", `Bearer ${token}`)
+                        .send(updatePayload);
+
+                expect(spy).toHaveBeenCalledWith(refuelId, userId, updatePayload);
+                expect(res.status).toBe(200);
+                expect(res.body).toEqual(returned);
+        });
+
+        it("returns 404 when RefuelService.update throws 'Refuel not found'", async () => {
+                jest.spyOn(RefuelService, "update").mockRejectedValue(new Error("Refuel not found"));
+
+                const res = await request(app)
+                        .put(`/api/v1/refuels/${refuelId}`)
+                        .set("Authorization", `Bearer ${token}`)
+                        .send(updatePayload);
+
+                expect(res.status).toBe(404);
+                expect(res.body).toMatchObject({ message: "Refuel not found" });
+        });
+});
+
+describe("RefuelController – GET /api/v1/refuels", () => {
+        const userId = "user123";
+        const token = jwt.sign({ sub: userId, email: "x@example.com" }, env.JWT_SECRET, { expiresIn: "1h" });
+
+        const returned = [
+                {
+                        id: "r1",
+                        userId,
+                        vehicleId: "veh1",
+                        fuelType: "petrol",
+                        note: "note",
+                        liters: 10,
+                        pricePerLiter: 1.2,
+                        totalPrice: 12,
+                        mileage: 1000,
+                        createdAt: new Date().toISOString(),
+                },
+        ];
+
+        afterEach(() => {
+                jest.resetAllMocks();
+        });
+
+        it("returns 401 if not authenticated", async () => {
+                const res = await request(app).get("/api/v1/refuels");
+                expect(res.status).toBe(401);
+                expect(res.body).toMatchObject({ message: expect.stringContaining("Unauthorized") });
+        });
+
+        it("calls RefuelService.list and returns 200 + payload", async () => {
+                const spy = jest.spyOn(RefuelService, "list").mockResolvedValue(returned as any);
+                const res = await request(app).get("/api/v1/refuels").set("Authorization", `Bearer ${token}`);
+                expect(spy).toHaveBeenCalledWith(userId);
+                expect(res.status).toBe(200);
+                expect(res.body).toEqual(returned);
+        });
+});
+
+describe("RefuelController – GET /api/v1/refuels/:id", () => {
+        const userId = "user123";
+        const token = jwt.sign({ sub: userId, email: "x@example.com" }, env.JWT_SECRET, { expiresIn: "1h" });
+        const id = "ref1";
+        const returned = {
+                id,
+                userId,
+                vehicleId: "veh1",
+                fuelType: "petrol",
+                note: "note",
+                liters: 10,
+                pricePerLiter: 1.2,
+                totalPrice: 12,
+                mileage: 1000,
+                createdAt: new Date().toISOString(),
+        };
+
+        afterEach(() => {
+                jest.resetAllMocks();
+        });
+
+        it("returns 401 if not authenticated", async () => {
+                const res = await request(app).get(`/api/v1/refuels/${id}`);
+                expect(res.status).toBe(401);
+                expect(res.body).toMatchObject({ message: expect.stringContaining("Unauthorized") });
+        });
+
+        it("returns 404 when refuel is not found", async () => {
+                jest.spyOn(RefuelService, "getById").mockResolvedValue(null);
+                const res = await request(app).get(`/api/v1/refuels/${id}`).set("Authorization", `Bearer ${token}`);
+                expect(res.status).toBe(404);
+                expect(res.body).toMatchObject({ message: expect.stringContaining("not found") });
+        });
+
+        it("calls RefuelService.getById and returns 200 + payload", async () => {
+                const spy = jest.spyOn(RefuelService, "getById").mockResolvedValue(returned as any);
+                const res = await request(app).get(`/api/v1/refuels/${id}`).set("Authorization", `Bearer ${token}`);
+                expect(spy).toHaveBeenCalledWith(id, userId);
+                expect(res.status).toBe(200);
+                expect(res.body).toEqual(returned);
+        });
+});
+
+describe("RefuelController – DELETE /api/v1/refuels/:id", () => {
+        const userId = "user123";
+        const refuelId = "ref123";
+        const token = jwt.sign({ sub: userId, email: "x@example.com" }, env.JWT_SECRET, { expiresIn: "1h" });
+
+        afterEach(() => {
+                jest.resetAllMocks();
+        });
+
+        it("returns 401 if not authenticated", async () => {
+                const res = await request(app).delete(`/api/v1/refuels/${refuelId}`);
+                expect(res.status).toBe(401);
+                expect(res.body).toMatchObject({ message: expect.stringContaining("Unauthorized") });
+        });
+
+        it("calls RefuelService.remove and returns 204 on success", async () => {
+                const spy = jest.spyOn(RefuelService, "remove").mockResolvedValue();
+                const res = await request(app)
+                        .delete(`/api/v1/refuels/${refuelId}`)
+                        .set("Authorization", `Bearer ${token}`);
+                expect(spy).toHaveBeenCalledWith(refuelId, userId);
+                expect(res.status).toBe(204);
+                expect(res.body).toEqual({});
+        });
+
+        it("returns 404 if refuel not found", async () => {
+                jest.spyOn(RefuelService, "remove").mockRejectedValue(new Error("Refuel not found"));
+                const res = await request(app)
+                        .delete(`/api/v1/refuels/${refuelId}`)
+                        .set("Authorization", `Bearer ${token}`);
+                expect(res.status).toBe(404);
+                expect(res.body).toEqual({ message: "Refuel not found" });
+        });
+
+        it("returns 500 if service throws", async () => {
+                jest.spyOn(RefuelService, "remove").mockRejectedValue(new Error("boom"));
+                const res = await request(app)
+                        .delete(`/api/v1/refuels/${refuelId}`)
+                        .set("Authorization", `Bearer ${token}`);
+                expect(res.status).toBe(500);
+                expect(res.body).toEqual({ message: "Refuel deletion failed" });
+        });
+});

--- a/tests/RefuelService.spec.ts
+++ b/tests/RefuelService.spec.ts
@@ -1,0 +1,170 @@
+import RefuelService, { CreateRefuelDTO } from "../src/services/RefuelService";
+import Refuel from "../src/models/Refuel";
+
+describe("RefuelService", () => {
+        const dto: CreateRefuelDTO = {
+                userId: "user1",
+                vehicleId: "veh1",
+                fuelType: "petrol",
+                note: "Test refuel",
+                liters: 50,
+                pricePerLiter: 1.2,
+                totalPrice: 60,
+                mileage: 12345,
+        };
+
+        afterEach(() => {
+                jest.restoreAllMocks();
+        });
+
+        describe("create()", () => {
+                it("should save a new refuel and return its details", async () => {
+                        const now = new Date();
+                        const saveSpy = jest.spyOn(Refuel.prototype, "save").mockImplementation(function (this: any) {
+                                this.createdAt = now;
+                                return Promise.resolve(this);
+                        });
+
+                        const result = await RefuelService.create(dto);
+
+                        expect(saveSpy).toHaveBeenCalled();
+                        expect(typeof result.id).toBe("string");
+                        expect(result).toMatchObject({
+                                userId: dto.userId,
+                                vehicleId: dto.vehicleId,
+                                fuelType: dto.fuelType,
+                                note: dto.note,
+                                liters: dto.liters,
+                                pricePerLiter: dto.pricePerLiter,
+                                totalPrice: dto.totalPrice,
+                                mileage: dto.mileage,
+                                createdAt: now,
+                        });
+                });
+
+                it("should throw if save fails", async () => {
+                        const dbError = new Error("DB failure");
+                        jest.spyOn(Refuel.prototype, "save").mockRejectedValue(dbError);
+                        await expect(RefuelService.create(dto)).rejects.toThrow("DB failure");
+                });
+        });
+
+        describe("getById()", () => {
+                const id = "ref1";
+
+                it("returns payload when found", async () => {
+                        const now = new Date();
+                        const found = {
+                                id,
+                                userId: dto.userId,
+                                vehicleId: dto.vehicleId,
+                                fuelType: dto.fuelType,
+                                note: dto.note,
+                                liters: dto.liters,
+                                pricePerLiter: dto.pricePerLiter,
+                                totalPrice: dto.totalPrice,
+                                mileage: dto.mileage,
+                                createdAt: now,
+                        };
+                        const spy = jest.spyOn(Refuel, "findOne").mockResolvedValue(found as any);
+
+                        const result = await RefuelService.getById(id, dto.userId);
+                        expect(spy).toHaveBeenCalledWith({ _id: id, userId: dto.userId });
+                        expect(result).toEqual(found);
+                });
+
+                it("returns null when not found", async () => {
+                        jest.spyOn(Refuel, "findOne").mockResolvedValue(null);
+                        const result = await RefuelService.getById(id, dto.userId);
+                        expect(result).toBeNull();
+                });
+
+                it("throws if lookup fails", async () => {
+                        const err = new Error("DB failure");
+                        jest.spyOn(Refuel, "findOne").mockRejectedValue(err);
+                        await expect(RefuelService.getById(id, dto.userId)).rejects.toThrow("DB failure");
+                });
+        });
+
+        describe("list()", () => {
+                it("returns refuels for user", async () => {
+                        const docs = [
+                                {
+                                        id: "r1",
+                                        userId: dto.userId,
+                                        vehicleId: dto.vehicleId,
+                                        fuelType: dto.fuelType,
+                                        note: dto.note,
+                                        liters: dto.liters,
+                                        pricePerLiter: dto.pricePerLiter,
+                                        totalPrice: dto.totalPrice,
+                                        mileage: dto.mileage,
+                                        createdAt: new Date(),
+                                },
+                        ];
+                        const spy = jest.spyOn(Refuel, "find").mockResolvedValue(docs as any);
+                        const res = await RefuelService.list(dto.userId);
+                        expect(spy).toHaveBeenCalledWith({ userId: dto.userId });
+                        expect(res).toEqual(docs);
+                });
+
+                it("throws if find fails", async () => {
+                        const dbError = new Error("DB failure");
+                        jest.spyOn(Refuel, "find").mockRejectedValue(dbError);
+                        await expect(RefuelService.list(dto.userId)).rejects.toThrow("DB failure");
+                });
+        });
+
+        describe("update()", () => {
+                const id = "ref123";
+                const userId = dto.userId;
+                const updatePayload = { note: "updated" };
+
+                it("updates and returns payload", async () => {
+                        const now = new Date();
+                        const updated = {
+                                id,
+                                userId,
+                                vehicleId: dto.vehicleId,
+                                fuelType: dto.fuelType,
+                                note: updatePayload.note,
+                                liters: dto.liters,
+                                pricePerLiter: dto.pricePerLiter,
+                                totalPrice: dto.totalPrice,
+                                mileage: dto.mileage,
+                                createdAt: now,
+                        };
+                        const spy = jest.spyOn(Refuel, "findOneAndUpdate").mockResolvedValue(updated as any);
+                        const result = await RefuelService.update(id, userId, updatePayload);
+                        expect(spy).toHaveBeenCalledWith({ _id: id, userId }, updatePayload, { new: true });
+                        expect(result).toEqual(updated);
+                });
+
+                it("throws when not found", async () => {
+                        jest.spyOn(Refuel, "findOneAndUpdate").mockResolvedValue(null as any);
+                        await expect(RefuelService.update(id, userId, updatePayload)).rejects.toThrow("Refuel not found");
+                });
+        });
+
+        describe("remove()", () => {
+                const id = "ref123";
+                const userId = dto.userId;
+
+                it("deletes refuel", async () => {
+                        const spy = jest.spyOn(Refuel, "findOneAndDelete").mockResolvedValue({ id } as any);
+                        await RefuelService.remove(id, userId);
+                        expect(spy).toHaveBeenCalledWith({ _id: id, userId });
+                });
+
+                it("throws if not found", async () => {
+                        jest.spyOn(Refuel, "findOneAndDelete").mockResolvedValue(null);
+                        await expect(RefuelService.remove(id, userId)).rejects.toThrow("Refuel not found");
+                });
+
+                it("throws if delete fails", async () => {
+                        const dbError = new Error("DB failure");
+                        jest.spyOn(Refuel, "findOneAndDelete").mockRejectedValue(dbError);
+                        await expect(RefuelService.remove(id, userId)).rejects.toThrow("DB failure");
+                });
+        });
+});


### PR DESCRIPTION
## Summary
- add Refuel model, service, and controller
- expose refuel CRUD routes
- cover refuel logic with service and controller tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af6c7a7fb48325997af6f1be731802