### PR TITLE
feat: add service records

### DIFF
--- a/API.md
+++ b/API.md
@@ -371,3 +371,138 @@ fetch(`http://localhost:3000/api/v1/refuels/${id}`, {
 });
 ```
 
+### GET /api/v1/services
+List service records.
+
+#### Curl
+```bash
+curl http://localhost:3000/api/v1/services \
+  -H "Authorization: Bearer TOKEN"
+```
+
+#### fetch
+```javascript
+fetch('http://localhost:3000/api/v1/services', {
+  headers: { Authorization: 'Bearer TOKEN' }
+});
+```
+
+### POST /api/v1/services
+Create a service record.
+
+**Body**
+```json
+{
+  "vehicleId": "id-of-vehicle",
+  "serviceType": "oil_filter",
+  "customType": "optional",
+  "itemName": "model or name",
+  "cost": 100,
+  "mileage": 12345,
+  "shop": "My Garage",
+  "selfService": true,
+  "note": "optional",
+  "photos": ["url1"],
+  "date": "2024-01-01T00:00:00.000Z"
+}
+```
+
+#### Curl
+```bash
+curl -X POST http://localhost:3000/api/v1/services \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"vehicleId":"id","serviceType":"oil_filter","cost":100,"mileage":12345,"date":"2024-01-01T00:00:00.000Z"}'
+```
+
+#### fetch
+```javascript
+fetch('http://localhost:3000/api/v1/services', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    Authorization: 'Bearer TOKEN'
+  },
+  body: JSON.stringify({
+    vehicleId: 'id',
+    serviceType: 'oil_filter',
+    cost: 100,
+    mileage: 12345,
+    date: '2024-01-01T00:00:00.000Z'
+  })
+});
+```
+
+### GET /api/v1/services/{id}
+Get a service record by ID.
+
+#### Curl
+```bash
+curl http://localhost:3000/api/v1/services/SERVICE_ID \
+  -H "Authorization: Bearer TOKEN"
+```
+
+#### fetch
+```javascript
+fetch(`http://localhost:3000/api/v1/services/${id}`, {
+  headers: { Authorization: 'Bearer TOKEN' }
+});
+```
+
+### PUT /api/v1/services/{id}
+Update a service record. Same body fields as service creation.
+
+**Body**
+```json
+{
+  "vehicleId": "id-of-vehicle",
+  "serviceType": "air_filter",
+  "cost": 90,
+  "mileage": 13000,
+  "date": "2024-02-01T00:00:00.000Z"
+}
+```
+
+#### Curl
+```bash
+curl -X PUT http://localhost:3000/api/v1/services/SERVICE_ID \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"vehicleId":"id-of-vehicle","serviceType":"air_filter","cost":90,"mileage":13000,"date":"2024-02-01T00:00:00.000Z"}'
+```
+
+#### fetch
+```javascript
+fetch(`http://localhost:3000/api/v1/services/${id}`, {
+  method: 'PUT',
+  headers: {
+    'Content-Type': 'application/json',
+    Authorization: 'Bearer TOKEN'
+  },
+  body: JSON.stringify({
+    vehicleId: 'id-of-vehicle',
+    serviceType: 'air_filter',
+    cost: 90,
+    mileage: 13000,
+    date: '2024-02-01T00:00:00.000Z'
+  })
+});
+```
+
+### DELETE /api/v1/services/{id}
+Delete a service record.
+
+#### Curl
+```bash
+curl -X DELETE http://localhost:3000/api/v1/services/SERVICE_ID \
+  -H "Authorization: Bearer TOKEN"
+```
+
+#### fetch
+```javascript
+fetch(`http://localhost:3000/api/v1/services/${id}`, {
+  method: 'DELETE',
+  headers: { Authorization: 'Bearer TOKEN' }
+});
+```
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -201,6 +201,80 @@ paths:
       responses:
         '204':
           description: Deleted
+
+  '/api/v1/services':
+    get:
+      summary: List service records
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Array of service records
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ServiceRecord'
+    post:
+      summary: Create service record
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewServiceRecord'
+      responses:
+        '201':
+          description: Created service record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceRecord'
+  '/api/v1/services/{id}':
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get service record by ID
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Service record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceRecord'
+    put:
+      summary: Update service record
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewServiceRecord'
+      responses:
+        '200':
+          description: Updated service record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceRecord'
+    delete:
+      summary: Delete service record
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Deleted
 components:
   securitySchemes:
     bearerAuth:
@@ -319,3 +393,68 @@ components:
           type: number
         mileage:
           type: number
+    ServiceRecord:
+      type: object
+      properties:
+        id:
+          type: string
+        userId:
+          type: string
+        vehicleId:
+          type: string
+        serviceType:
+          type: string
+        customType:
+          type: string
+        itemName:
+          type: string
+        cost:
+          type: number
+        mileage:
+          type: number
+        shop:
+          type: string
+        selfService:
+          type: boolean
+        note:
+          type: string
+        photos:
+          type: array
+          items:
+            type: string
+        date:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+    NewServiceRecord:
+      type: object
+      required: [vehicleId, serviceType, cost, mileage, date]
+      properties:
+        vehicleId:
+          type: string
+        serviceType:
+          type: string
+        customType:
+          type: string
+        itemName:
+          type: string
+        cost:
+          type: number
+        mileage:
+          type: number
+        shop:
+          type: string
+        selfService:
+          type: boolean
+        note:
+          type: string
+        photos:
+          type: array
+          items:
+            type: string
+        date:
+          type: string
+          format: date-time
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -422,6 +422,7 @@ components:
           type: array
           items:
             type: string
+            format: byte
         date:
           type: string
           format: date-time
@@ -454,6 +455,7 @@ components:
           type: array
           items:
             type: string
+            format: byte
         date:
           type: string
           format: date-time

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -422,7 +422,7 @@ components:
           type: array
           items:
             type: string
-            format: byte
+            format: uri
         date:
           type: string
           format: date-time

--- a/src/controllers/ServiceRecordController.ts
+++ b/src/controllers/ServiceRecordController.ts
@@ -6,21 +6,26 @@ class ServiceRecordController {
 	static async create(req: Request, res: Response): Promise<Response> {
 		try {
 			const userId = (req as any).user.sub as string;
-			const dto = {
-				userId,
-				vehicleId: req.body.vehicleId,
-				serviceType: req.body.serviceType,
-				customType: req.body.customType,
-				itemName: req.body.itemName,
-				cost: req.body.cost,
-				mileage: req.body.mileage,
-				shop: req.body.shop,
-				selfService: req.body.selfService,
-				note: req.body.note,
-				photos: req.body.photos,
-				date: req.body.date,
-			};
-			const record = await ServiceRecordService.create(dto);
+                        const photos = Array.isArray(req.body.photos)
+                                ? (req.body.photos as string[]).map((p) => Buffer.from(p, "base64"))
+                                : req.body.photos
+                                        ? [Buffer.from(req.body.photos as string, "base64")]
+                                        : undefined;
+                        const dto = {
+                                userId,
+                                vehicleId: req.body.vehicleId,
+                                serviceType: req.body.serviceType,
+                                customType: req.body.customType,
+                                itemName: req.body.itemName,
+                                cost: Number(req.body.cost),
+                                mileage: Number(req.body.mileage),
+                                shop: req.body.shop,
+                                selfService: req.body.selfService === "true" || req.body.selfService === true,
+                                note: req.body.note,
+                                photos,
+                                date: new Date(req.body.date),
+                        };
+                        const record = await ServiceRecordService.create(dto);
 			new Succ(201, "Service record created", record);
 			return res.status(201).json(record);
 		} catch (err: any) {
@@ -62,20 +67,27 @@ class ServiceRecordController {
 		try {
 			const userId = (req as any).user.sub as string;
 			const id = req.params.id;
-			const payload = {
-				vehicleId: req.body.vehicleId,
-				serviceType: req.body.serviceType,
-				customType: req.body.customType,
-				itemName: req.body.itemName,
-				cost: req.body.cost,
-				mileage: req.body.mileage,
-				shop: req.body.shop,
-				selfService: req.body.selfService,
-				note: req.body.note,
-				photos: req.body.photos,
-				date: req.body.date,
-			};
-			const record = await ServiceRecordService.update(id, userId, payload);
+                        const photos = Array.isArray(req.body.photos)
+                                ? (req.body.photos as string[]).map((p) => Buffer.from(p, "base64"))
+                                : req.body.photos
+                                        ? [Buffer.from(req.body.photos as string, "base64")]
+                                        : undefined;
+                        const payload: any = {
+                                vehicleId: req.body.vehicleId,
+                                serviceType: req.body.serviceType,
+                                customType: req.body.customType,
+                                itemName: req.body.itemName,
+                                cost: req.body.cost ? Number(req.body.cost) : undefined,
+                                mileage: req.body.mileage ? Number(req.body.mileage) : undefined,
+                                shop: req.body.shop,
+                                selfService: req.body.selfService === "true" || req.body.selfService === true,
+                                note: req.body.note,
+                                date: req.body.date ? new Date(req.body.date) : undefined,
+                        };
+                        if (photos) {
+                                payload.photos = photos;
+                        }
+                        const record = await ServiceRecordService.update(id, userId, payload);
 			new Succ(200, "Service record updated", record);
 			return res.status(200).json(record);
 		} catch (err: any) {

--- a/src/controllers/ServiceRecordController.ts
+++ b/src/controllers/ServiceRecordController.ts
@@ -1,0 +1,109 @@
+import { Request, Response } from "express";
+import ServiceRecordService from "../services/ServiceRecordService";
+import { Err, Succ } from "../services/globalService";
+
+class ServiceRecordController {
+	static async create(req: Request, res: Response): Promise<Response> {
+		try {
+			const userId = (req as any).user.sub as string;
+			const dto = {
+				userId,
+				vehicleId: req.body.vehicleId,
+				serviceType: req.body.serviceType,
+				customType: req.body.customType,
+				itemName: req.body.itemName,
+				cost: req.body.cost,
+				mileage: req.body.mileage,
+				shop: req.body.shop,
+				selfService: req.body.selfService,
+				note: req.body.note,
+				photos: req.body.photos,
+				date: req.body.date,
+			};
+			const record = await ServiceRecordService.create(dto);
+			new Succ(201, "Service record created", record);
+			return res.status(201).json(record);
+		} catch (err: any) {
+			new Err(500, "Service record creation failed", err);
+			return res.status(500).json({ message: "Service record creation failed" });
+		}
+	}
+
+	static async show(req: Request, res: Response): Promise<Response> {
+		try {
+			const userId = (req as any).user.sub as string;
+			const id = req.params.id;
+			const record = await ServiceRecordService.getById(id, userId);
+			if (!record) {
+				new Err(404, "Service record not found", { id, userId });
+				return res.status(404).json({ message: "Service record not found" });
+			}
+			new Succ(200, "Service record fetched", record);
+			return res.status(200).json(record);
+		} catch (err: any) {
+			new Err(500, "Service record fetch failed", err);
+			return res.status(500).json({ message: "Service record fetch failed" });
+		}
+	}
+
+	static async list(req: Request, res: Response): Promise<Response> {
+		try {
+			const userId = (req as any).user.sub as string;
+			const records = await ServiceRecordService.list(userId);
+			new Succ(200, "Fetched service records", records);
+			return res.status(200).json(records);
+		} catch (err: any) {
+			new Err(500, "Service record fetch failed", err);
+			return res.status(500).json({ message: "Service record fetch failed" });
+		}
+	}
+
+	static async update(req: Request, res: Response): Promise<Response> {
+		try {
+			const userId = (req as any).user.sub as string;
+			const id = req.params.id;
+			const payload = {
+				vehicleId: req.body.vehicleId,
+				serviceType: req.body.serviceType,
+				customType: req.body.customType,
+				itemName: req.body.itemName,
+				cost: req.body.cost,
+				mileage: req.body.mileage,
+				shop: req.body.shop,
+				selfService: req.body.selfService,
+				note: req.body.note,
+				photos: req.body.photos,
+				date: req.body.date,
+			};
+			const record = await ServiceRecordService.update(id, userId, payload);
+			new Succ(200, "Service record updated", record);
+			return res.status(200).json(record);
+		} catch (err: any) {
+			if (err.message === "Service record not found") {
+				new Err(404, "Service record not found", err);
+				return res.status(404).json({ message: "Service record not found" });
+			}
+			new Err(500, "Service record update failed", err);
+			return res.status(500).json({ message: "Service record update failed" });
+		}
+	}
+
+	static async remove(req: Request, res: Response): Promise<Response> {
+		try {
+			const userId = (req as any).user.sub as string;
+			const id = req.params.id;
+			await ServiceRecordService.remove(id, userId);
+			new Succ(204, "Service record deleted", { id });
+			return res.status(204).send();
+		} catch (err: any) {
+			if (err.message === "Service record not found") {
+				new Err(404, "Service record not found", err);
+				return res.status(404).json({ message: "Service record not found" });
+			}
+			new Err(500, "Service record deletion failed", err);
+			return res.status(500).json({ message: "Service record deletion failed" });
+		}
+	}
+}
+
+export default ServiceRecordController;

--- a/src/models/ServiceRecord.ts
+++ b/src/models/ServiceRecord.ts
@@ -10,10 +10,10 @@ export interface IServiceRecord extends Document {
 	mileage: number;
 	shop?: string;
 	selfService?: boolean;
-	note?: string;
-	photos?: string[];
-	date: Date;
-	createdAt: Date;
+        note?: string;
+        photos?: Buffer[];
+        date: Date;
+        createdAt: Date;
 }
 
 const serviceRecordSchema = new Schema<IServiceRecord>(
@@ -27,9 +27,9 @@ const serviceRecordSchema = new Schema<IServiceRecord>(
 		mileage: { type: Number, required: true },
 		shop: { type: String },
 		selfService: { type: Boolean, default: false },
-		note: { type: String },
-		photos: { type: [String], default: [] },
-		date: { type: Date, required: true },
+                note: { type: String },
+                photos: { type: [Buffer], default: [] },
+                date: { type: Date, required: true },
 	},
 	{ timestamps: { createdAt: true, updatedAt: false } },
 );

--- a/src/models/ServiceRecord.ts
+++ b/src/models/ServiceRecord.ts
@@ -1,0 +1,38 @@
+import { Schema, model, Document } from "mongoose";
+
+export interface IServiceRecord extends Document {
+	userId: string;
+	vehicleId: string;
+	serviceType: string;
+	customType?: string;
+	itemName?: string;
+	cost: number;
+	mileage: number;
+	shop?: string;
+	selfService?: boolean;
+	note?: string;
+	photos?: string[];
+	date: Date;
+	createdAt: Date;
+}
+
+const serviceRecordSchema = new Schema<IServiceRecord>(
+	{
+		userId: { type: String, required: true, index: true },
+		vehicleId: { type: String, required: true, index: true },
+		serviceType: { type: String, required: true },
+		customType: { type: String },
+		itemName: { type: String },
+		cost: { type: Number, required: true },
+		mileage: { type: Number, required: true },
+		shop: { type: String },
+		selfService: { type: Boolean, default: false },
+		note: { type: String },
+		photos: { type: [String], default: [] },
+		date: { type: Date, required: true },
+	},
+	{ timestamps: { createdAt: true, updatedAt: false } },
+);
+
+const ServiceRecord = model<IServiceRecord>("ServiceRecord", serviceRecordSchema);
+export default ServiceRecord;

--- a/src/models/ServiceRecord.ts
+++ b/src/models/ServiceRecord.ts
@@ -11,7 +11,7 @@ export interface IServiceRecord extends Document {
 	shop?: string;
 	selfService?: boolean;
         note?: string;
-        photos?: Buffer[];
+        photos?: string[];
         date: Date;
         createdAt: Date;
 }
@@ -28,9 +28,9 @@ const serviceRecordSchema = new Schema<IServiceRecord>(
 		shop: { type: String },
 		selfService: { type: Boolean, default: false },
                 note: { type: String },
-                photos: { type: [Buffer], default: [] },
+                photos: { type: [String], default: [] },
                 date: { type: Date, required: true },
-	},
+        },
 	{ timestamps: { createdAt: true, updatedAt: false } },
 );
 

--- a/src/routes/ServiceRecordRoutes.ts
+++ b/src/routes/ServiceRecordRoutes.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import ServiceRecordController from "../controllers/ServiceRecordController";
+import { requireAuth } from "../middlewares/AuthMiddleware";
+
+const router = Router();
+
+router.get("/", requireAuth, ServiceRecordController.list);
+router.post("/", requireAuth, ServiceRecordController.create);
+router.get("/:id", requireAuth, ServiceRecordController.show);
+router.put("/:id", requireAuth, ServiceRecordController.update);
+router.delete("/:id", requireAuth, ServiceRecordController.remove);
+
+export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,6 +4,7 @@ import AuthRoutes from "./AuthRoutes";
 import UserRoutes from "./UserRoutes";
 import VehicleRoutes from "./VehicleRoutes";
 import RefuelRoutes from "./RefuelRoutes";
+import ServiceRecordRoutes from "./ServiceRecordRoutes";
 
 export const router = Router();
 
@@ -12,6 +13,7 @@ router.use("/api/v1/auth", AuthRoutes);
 router.use("/api/v1/user", UserRoutes);
 router.use("/api/v1/vehicles", VehicleRoutes);
 router.use("/api/v1/refuels", RefuelRoutes);
+router.use("/api/v1/services", ServiceRecordRoutes);
 
 // 404
 router.use((req: Request, res: Response) => {

--- a/src/services/ServiceRecordService.ts
+++ b/src/services/ServiceRecordService.ts
@@ -1,0 +1,197 @@
+import ServiceRecord, { IServiceRecord } from "../models/ServiceRecord";
+import { Err, Succ } from "./globalService";
+
+export interface CreateServiceRecordDTO {
+	userId: string;
+	vehicleId: string;
+	serviceType: string;
+	customType?: string;
+	itemName?: string;
+	cost: number;
+	mileage: number;
+	shop?: string;
+	selfService?: boolean;
+	note?: string;
+	photos?: string[];
+	date: Date;
+}
+
+export interface ServiceRecordPayload {
+	id: string;
+	userId: string;
+	vehicleId: string;
+	serviceType: string;
+	customType?: string;
+	itemName?: string;
+	cost: number;
+	mileage: number;
+	shop?: string;
+	selfService?: boolean;
+	note?: string;
+	photos?: string[];
+	date: Date;
+	createdAt: Date;
+}
+
+class ServiceRecordService {
+	static async create(data: CreateServiceRecordDTO): Promise<ServiceRecordPayload> {
+		try {
+			const record = new ServiceRecord({
+				userId: data.userId,
+				vehicleId: data.vehicleId,
+				serviceType: data.serviceType,
+				customType: data.customType,
+				itemName: data.itemName,
+				cost: data.cost,
+				mileage: data.mileage,
+				shop: data.shop,
+				selfService: data.selfService,
+				note: data.note,
+				photos: data.photos,
+				date: data.date,
+			} as Partial<IServiceRecord>);
+
+			await record.save();
+
+			const payload: ServiceRecordPayload = {
+				id: record.id,
+				userId: record.userId,
+				vehicleId: record.vehicleId,
+				serviceType: record.serviceType,
+				customType: record.customType,
+				itemName: record.itemName,
+				cost: record.cost,
+				mileage: record.mileage,
+				shop: record.shop,
+				selfService: record.selfService,
+				note: record.note,
+				photos: record.photos,
+				date: record.date,
+				createdAt: record.createdAt,
+			};
+
+			new Succ(201, "Service record created", payload);
+			return payload;
+		} catch (err: any) {
+			new Err(500, "Service record creation failed", err);
+			throw err;
+		}
+	}
+
+	static async getById(id: string, userId: string): Promise<ServiceRecordPayload | null> {
+		try {
+			const record = await ServiceRecord.findOne({ _id: id, userId });
+			if (!record) {
+				new Err(404, "Service record not found", { id, userId });
+				return null;
+			}
+
+			const payload: ServiceRecordPayload = {
+				id: record.id,
+				userId: record.userId,
+				vehicleId: record.vehicleId,
+				serviceType: record.serviceType,
+				customType: record.customType,
+				itemName: record.itemName,
+				cost: record.cost,
+				mileage: record.mileage,
+				shop: record.shop,
+				selfService: record.selfService,
+				note: record.note,
+				photos: record.photos,
+				date: record.date,
+				createdAt: record.createdAt,
+			};
+
+			new Succ(200, "Service record fetched", payload);
+			return payload;
+		} catch (err: any) {
+			new Err(500, "Service record fetch failed", err);
+			throw err;
+		}
+	}
+
+	static async list(userId: string): Promise<ServiceRecordPayload[]> {
+		try {
+			const records = await ServiceRecord.find({ userId });
+			const payload = records.map((r) => ({
+				id: r.id,
+				userId: r.userId,
+				vehicleId: r.vehicleId,
+				serviceType: r.serviceType,
+				customType: r.customType,
+				itemName: r.itemName,
+				cost: r.cost,
+				mileage: r.mileage,
+				shop: r.shop,
+				selfService: r.selfService,
+				note: r.note,
+				photos: r.photos,
+				date: r.date,
+				createdAt: r.createdAt,
+			}));
+			new Succ(200, "Fetched service records", payload);
+			return payload;
+		} catch (err: any) {
+			new Err(500, "Service record fetch failed", err);
+			throw err;
+		}
+	}
+
+	static async update(
+		id: string,
+		userId: string,
+		payload: Partial<Pick<IServiceRecord, "vehicleId" | "serviceType" | "customType" | "itemName" | "cost" | "mileage" | "shop" | "selfService" | "note" | "photos" | "date">>,
+	): Promise<ServiceRecordPayload> {
+		try {
+			const updated = await ServiceRecord.findOneAndUpdate({ _id: id, userId }, payload, { new: true });
+			if (!updated) {
+				new Err(404, "Service record not found");
+				throw new Error("Service record not found");
+			}
+			const result: ServiceRecordPayload = {
+				id: updated.id,
+				userId: updated.userId,
+				vehicleId: updated.vehicleId,
+				serviceType: updated.serviceType,
+				customType: updated.customType,
+				itemName: updated.itemName,
+				cost: updated.cost,
+				mileage: updated.mileage,
+				shop: updated.shop,
+				selfService: updated.selfService,
+				note: updated.note,
+				photos: updated.photos,
+				date: updated.date,
+				createdAt: updated.createdAt,
+			};
+			new Succ(200, "Service record updated", result);
+			return result;
+		} catch (err: any) {
+			if (err.message === "Service record not found") {
+				throw err;
+			}
+			new Err(500, "Service record update failed", err);
+			throw err;
+		}
+	}
+
+	static async remove(id: string, userId: string): Promise<void> {
+		try {
+			const deleted = await ServiceRecord.findOneAndDelete({ _id: id, userId });
+			if (!deleted) {
+				new Err(404, "Service record not found or not owned by user", { id, userId });
+				throw new Error("Service record not found");
+			}
+			new Succ(200, "Service record removed", { id });
+		} catch (err: any) {
+			if (err.message === "Service record not found") {
+				throw err;
+			}
+			new Err(500, "Service record deletion failed", err);
+			throw err;
+		}
+	}
+}
+
+export default ServiceRecordService;

--- a/src/services/ServiceRecordService.ts
+++ b/src/services/ServiceRecordService.ts
@@ -12,7 +12,7 @@ export interface CreateServiceRecordDTO {
 	shop?: string;
 	selfService?: boolean;
         note?: string;
-        photos?: Buffer[];
+        photos?: string[];
         date: Date;
 }
 
@@ -65,7 +65,7 @@ class ServiceRecordService {
 				shop: record.shop,
 				selfService: record.selfService,
                                 note: record.note,
-                                photos: record.photos?.map((p) => p.toString("base64")),
+                                photos: record.photos?.map((p) => `/uploads/${p}`),
                                 date: record.date,
                                 createdAt: record.createdAt,
                         };
@@ -98,7 +98,7 @@ class ServiceRecordService {
 				shop: record.shop,
 				selfService: record.selfService,
                                 note: record.note,
-                                photos: record.photos?.map((p) => p.toString("base64")),
+                                photos: record.photos?.map((p) => `/uploads/${p}`),
                                 date: record.date,
                                 createdAt: record.createdAt,
                         };
@@ -126,7 +126,7 @@ class ServiceRecordService {
 				shop: r.shop,
 				selfService: r.selfService,
                                 note: r.note,
-                                photos: r.photos?.map((p) => p.toString("base64")),
+                                photos: r.photos?.map((p) => `/uploads/${p}`),
                                 date: r.date,
                                 createdAt: r.createdAt,
                         }));
@@ -161,7 +161,7 @@ class ServiceRecordService {
 				shop: updated.shop,
 				selfService: updated.selfService,
                                 note: updated.note,
-                                photos: updated.photos?.map((p) => p.toString("base64")),
+                                photos: updated.photos?.map((p) => `/uploads/${p}`),
                                 date: updated.date,
                                 createdAt: updated.createdAt,
                         };

--- a/src/services/ServiceRecordService.ts
+++ b/src/services/ServiceRecordService.ts
@@ -11,9 +11,9 @@ export interface CreateServiceRecordDTO {
 	mileage: number;
 	shop?: string;
 	selfService?: boolean;
-	note?: string;
-	photos?: string[];
-	date: Date;
+        note?: string;
+        photos?: Buffer[];
+        date: Date;
 }
 
 export interface ServiceRecordPayload {
@@ -27,10 +27,10 @@ export interface ServiceRecordPayload {
 	mileage: number;
 	shop?: string;
 	selfService?: boolean;
-	note?: string;
-	photos?: string[];
-	date: Date;
-	createdAt: Date;
+        note?: string;
+        photos?: string[];
+        date: Date;
+        createdAt: Date;
 }
 
 class ServiceRecordService {
@@ -46,10 +46,10 @@ class ServiceRecordService {
 				mileage: data.mileage,
 				shop: data.shop,
 				selfService: data.selfService,
-				note: data.note,
-				photos: data.photos,
-				date: data.date,
-			} as Partial<IServiceRecord>);
+                                note: data.note,
+                                photos: data.photos,
+                                date: data.date,
+                        } as Partial<IServiceRecord>);
 
 			await record.save();
 
@@ -64,11 +64,11 @@ class ServiceRecordService {
 				mileage: record.mileage,
 				shop: record.shop,
 				selfService: record.selfService,
-				note: record.note,
-				photos: record.photos,
-				date: record.date,
-				createdAt: record.createdAt,
-			};
+                                note: record.note,
+                                photos: record.photos?.map((p) => p.toString("base64")),
+                                date: record.date,
+                                createdAt: record.createdAt,
+                        };
 
 			new Succ(201, "Service record created", payload);
 			return payload;
@@ -97,11 +97,11 @@ class ServiceRecordService {
 				mileage: record.mileage,
 				shop: record.shop,
 				selfService: record.selfService,
-				note: record.note,
-				photos: record.photos,
-				date: record.date,
-				createdAt: record.createdAt,
-			};
+                                note: record.note,
+                                photos: record.photos?.map((p) => p.toString("base64")),
+                                date: record.date,
+                                createdAt: record.createdAt,
+                        };
 
 			new Succ(200, "Service record fetched", payload);
 			return payload;
@@ -125,11 +125,11 @@ class ServiceRecordService {
 				mileage: r.mileage,
 				shop: r.shop,
 				selfService: r.selfService,
-				note: r.note,
-				photos: r.photos,
-				date: r.date,
-				createdAt: r.createdAt,
-			}));
+                                note: r.note,
+                                photos: r.photos?.map((p) => p.toString("base64")),
+                                date: r.date,
+                                createdAt: r.createdAt,
+                        }));
 			new Succ(200, "Fetched service records", payload);
 			return payload;
 		} catch (err: any) {
@@ -141,8 +141,8 @@ class ServiceRecordService {
 	static async update(
 		id: string,
 		userId: string,
-		payload: Partial<Pick<IServiceRecord, "vehicleId" | "serviceType" | "customType" | "itemName" | "cost" | "mileage" | "shop" | "selfService" | "note" | "photos" | "date">>,
-	): Promise<ServiceRecordPayload> {
+                payload: Partial<Pick<IServiceRecord, "vehicleId" | "serviceType" | "customType" | "itemName" | "cost" | "mileage" | "shop" | "selfService" | "note" | "photos" | "date">>,
+        ): Promise<ServiceRecordPayload> {
 		try {
 			const updated = await ServiceRecord.findOneAndUpdate({ _id: id, userId }, payload, { new: true });
 			if (!updated) {
@@ -160,11 +160,11 @@ class ServiceRecordService {
 				mileage: updated.mileage,
 				shop: updated.shop,
 				selfService: updated.selfService,
-				note: updated.note,
-				photos: updated.photos,
-				date: updated.date,
-				createdAt: updated.createdAt,
-			};
+                                note: updated.note,
+                                photos: updated.photos?.map((p) => p.toString("base64")),
+                                date: updated.date,
+                                createdAt: updated.createdAt,
+                        };
 			new Succ(200, "Service record updated", result);
 			return result;
 		} catch (err: any) {

--- a/tests/ServiceRecordController.spec.ts
+++ b/tests/ServiceRecordController.spec.ts
@@ -1,0 +1,202 @@
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { app } from "../src/app";
+import ServiceRecordService from "../src/services/ServiceRecordService";
+import env from "../src/config/environment";
+
+describe("ServiceRecordController – POST /api/v1/services", () => {
+	const userId = "user123";
+	const token = jwt.sign({ sub: userId, email: "x@example.com" }, env.JWT_SECRET, { expiresIn: "1h" });
+
+	const createDto = {
+		userId,
+		vehicleId: "veh1",
+		serviceType: "oil_filter",
+		itemName: "OEM",
+		cost: 40,
+		mileage: 1000,
+		date: "2024-01-01T00:00:00.000Z",
+	};
+
+	const returned = { ...createDto, id: "srv1", createdAt: new Date().toISOString() };
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it("returns 401 if not authenticated", async () => {
+		const res = await request(app).post("/api/v1/services").send(createDto);
+		expect(res.status).toBe(401);
+		expect(res.body).toMatchObject({ message: expect.stringContaining("Unauthorized") });
+	});
+
+	it("calls ServiceRecordService.create and returns 201 + payload", async () => {
+		const spy = jest.spyOn(ServiceRecordService, "create").mockResolvedValue(returned as any);
+
+		const res = await request(app).post("/api/v1/services").set("Authorization", `Bearer ${token}`).send({
+			vehicleId: createDto.vehicleId,
+			serviceType: createDto.serviceType,
+			itemName: createDto.itemName,
+			cost: createDto.cost,
+			mileage: createDto.mileage,
+			date: createDto.date,
+		});
+
+		expect(spy).toHaveBeenCalledWith({
+			userId,
+			vehicleId: createDto.vehicleId,
+			serviceType: createDto.serviceType,
+			itemName: createDto.itemName,
+			cost: createDto.cost,
+			mileage: createDto.mileage,
+			date: createDto.date,
+		});
+		expect(res.status).toBe(201);
+		expect(res.body).toEqual(returned);
+	});
+});
+
+describe("ServiceRecordController – PUT /api/v1/services/:id", () => {
+	const userId = "user123";
+	const recordId = "srv789";
+	const token = jwt.sign({ sub: userId, email: "x@example.com" }, env.JWT_SECRET, { expiresIn: "1h" });
+
+	const updatePayload = { cost: 60 };
+	const returned = {
+		id: recordId,
+		userId,
+		vehicleId: "veh1",
+		serviceType: "oil_filter",
+		itemName: "OEM",
+		cost: updatePayload.cost,
+		mileage: 1000,
+		date: "2024-01-01T00:00:00.000Z",
+		createdAt: new Date().toISOString(),
+	};
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it("returns 401 if not authenticated", async () => {
+		const res = await request(app).put(`/api/v1/services/${recordId}`).send(updatePayload);
+		expect(res.status).toBe(401);
+		expect(res.body).toMatchObject({ message: expect.stringContaining("Unauthorized") });
+	});
+
+	it("calls ServiceRecordService.update and returns 200 + payload", async () => {
+		const spy = jest.spyOn(ServiceRecordService, "update").mockResolvedValue(returned as any);
+
+		const res = await request(app).put(`/api/v1/services/${recordId}`).set("Authorization", `Bearer ${token}`).send(updatePayload);
+
+		expect(spy).toHaveBeenCalledWith(recordId, userId, updatePayload);
+		expect(res.status).toBe(200);
+		expect(res.body).toEqual(returned);
+	});
+
+	it("returns 404 when ServiceRecordService.update throws 'Service record not found'", async () => {
+		jest.spyOn(ServiceRecordService, "update").mockRejectedValue(new Error("Service record not found"));
+
+		const res = await request(app).put(`/api/v1/services/${recordId}`).set("Authorization", `Bearer ${token}`).send(updatePayload);
+
+		expect(res.status).toBe(404);
+		expect(res.body).toEqual({ message: "Service record not found" });
+	});
+});
+
+describe("ServiceRecordController – GET /api/v1/services", () => {
+	const userId = "user123";
+	const token = jwt.sign({ sub: userId, email: "x@example.com" }, env.JWT_SECRET, { expiresIn: "1h" });
+
+	const returned = [
+		{ id: "r1", userId, vehicleId: "veh1", serviceType: "oil_filter", itemName: "OEM", cost: 40, mileage: 1000, date: "2024-01-01T00:00:00.000Z", createdAt: new Date().toISOString() },
+	];
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it("returns 401 if not authenticated", async () => {
+		const res = await request(app).get("/api/v1/services");
+		expect(res.status).toBe(401);
+		expect(res.body).toMatchObject({ message: expect.stringContaining("Unauthorized") });
+	});
+
+	it("calls ServiceRecordService.list and returns 200 + payload", async () => {
+		const spy = jest.spyOn(ServiceRecordService, "list").mockResolvedValue(returned as any);
+		const res = await request(app).get("/api/v1/services").set("Authorization", `Bearer ${token}`);
+		expect(spy).toHaveBeenCalledWith(userId);
+		expect(res.status).toBe(200);
+		expect(res.body).toEqual(returned);
+	});
+});
+
+describe("ServiceRecordController – GET /api/v1/services/:id", () => {
+	const userId = "user123";
+	const token = jwt.sign({ sub: userId, email: "x@example.com" }, env.JWT_SECRET, { expiresIn: "1h" });
+	const id = "srv1";
+	const returned = { id, userId, vehicleId: "veh1", serviceType: "oil_filter", itemName: "OEM", cost: 40, mileage: 1000, date: "2024-01-01T00:00:00.000Z", createdAt: new Date().toISOString() };
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it("returns 401 if not authenticated", async () => {
+		const res = await request(app).get(`/api/v1/services/${id}`);
+		expect(res.status).toBe(401);
+		expect(res.body).toMatchObject({ message: expect.stringContaining("Unauthorized") });
+	});
+
+	it("returns 404 when record is not found", async () => {
+		jest.spyOn(ServiceRecordService, "getById").mockResolvedValue(null);
+		const res = await request(app).get(`/api/v1/services/${id}`).set("Authorization", `Bearer ${token}`);
+		expect(res.status).toBe(404);
+		expect(res.body).toMatchObject({ message: expect.stringContaining("not found") });
+	});
+
+	it("calls ServiceRecordService.getById and returns 200 + payload", async () => {
+		const spy = jest.spyOn(ServiceRecordService, "getById").mockResolvedValue(returned as any);
+		const res = await request(app).get(`/api/v1/services/${id}`).set("Authorization", `Bearer ${token}`);
+		expect(spy).toHaveBeenCalledWith(id, userId);
+		expect(res.status).toBe(200);
+		expect(res.body).toEqual(returned);
+	});
+});
+
+describe("ServiceRecordController – DELETE /api/v1/services/:id", () => {
+	const userId = "user123";
+	const recordId = "srv123";
+	const token = jwt.sign({ sub: userId, email: "x@example.com" }, env.JWT_SECRET, { expiresIn: "1h" });
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it("returns 401 if not authenticated", async () => {
+		const res = await request(app).delete(`/api/v1/services/${recordId}`);
+		expect(res.status).toBe(401);
+		expect(res.body).toMatchObject({ message: expect.stringContaining("Unauthorized") });
+	});
+
+	it("calls ServiceRecordService.remove and returns 204 on success", async () => {
+		const spy = jest.spyOn(ServiceRecordService, "remove").mockResolvedValue();
+		const res = await request(app).delete(`/api/v1/services/${recordId}`).set("Authorization", `Bearer ${token}`);
+		expect(spy).toHaveBeenCalledWith(recordId, userId);
+		expect(res.status).toBe(204);
+		expect(res.body).toEqual({});
+	});
+
+	it("returns 404 if record not found", async () => {
+		jest.spyOn(ServiceRecordService, "remove").mockRejectedValue(new Error("Service record not found"));
+		const res = await request(app).delete(`/api/v1/services/${recordId}`).set("Authorization", `Bearer ${token}`);
+		expect(res.status).toBe(404);
+		expect(res.body).toEqual({ message: "Service record not found" });
+	});
+
+	it("returns 500 if service throws", async () => {
+		jest.spyOn(ServiceRecordService, "remove").mockRejectedValue(new Error("boom"));
+		const res = await request(app).delete(`/api/v1/services/${recordId}`).set("Authorization", `Bearer ${token}`);
+		expect(res.status).toBe(500);
+		expect(res.body).toEqual({ message: "Service record deletion failed" });
+	});
+});

--- a/tests/ServiceRecordController.spec.ts
+++ b/tests/ServiceRecordController.spec.ts
@@ -30,30 +30,35 @@ describe("ServiceRecordController – POST /api/v1/services", () => {
 		expect(res.body).toMatchObject({ message: expect.stringContaining("Unauthorized") });
 	});
 
-	it("calls ServiceRecordService.create and returns 201 + payload", async () => {
-		const spy = jest.spyOn(ServiceRecordService, "create").mockResolvedValue(returned as any);
+        it("calls ServiceRecordService.create and returns 201 + payload", async () => {
+                const spy = jest.spyOn(ServiceRecordService, "create").mockResolvedValue(returned as any);
 
-		const res = await request(app).post("/api/v1/services").set("Authorization", `Bearer ${token}`).send({
-			vehicleId: createDto.vehicleId,
-			serviceType: createDto.serviceType,
-			itemName: createDto.itemName,
-			cost: createDto.cost,
-			mileage: createDto.mileage,
-			date: createDto.date,
-		});
+                const res = await request(app)
+                        .post("/api/v1/services")
+                        .set("Authorization", `Bearer ${token}`)
+                        .send({
+                                vehicleId: createDto.vehicleId,
+                                serviceType: createDto.serviceType,
+                                itemName: createDto.itemName,
+                                cost: createDto.cost,
+                                mileage: createDto.mileage,
+                                date: createDto.date,
+                        });
 
-		expect(spy).toHaveBeenCalledWith({
-			userId,
-			vehicleId: createDto.vehicleId,
-			serviceType: createDto.serviceType,
-			itemName: createDto.itemName,
-			cost: createDto.cost,
-			mileage: createDto.mileage,
-			date: createDto.date,
-		});
-		expect(res.status).toBe(201);
-		expect(res.body).toEqual(returned);
-	});
+                expect(spy).toHaveBeenCalledWith(
+                        expect.objectContaining({
+                                userId,
+                                vehicleId: createDto.vehicleId,
+                                serviceType: createDto.serviceType,
+                                itemName: createDto.itemName,
+                                cost: createDto.cost,
+                                mileage: createDto.mileage,
+                                date: new Date(createDto.date),
+                        }),
+                );
+                expect(res.status).toBe(201);
+                expect(res.body).toEqual(returned);
+        });
 });
 
 describe("ServiceRecordController – PUT /api/v1/services/:id", () => {
@@ -84,15 +89,18 @@ describe("ServiceRecordController – PUT /api/v1/services/:id", () => {
 		expect(res.body).toMatchObject({ message: expect.stringContaining("Unauthorized") });
 	});
 
-	it("calls ServiceRecordService.update and returns 200 + payload", async () => {
-		const spy = jest.spyOn(ServiceRecordService, "update").mockResolvedValue(returned as any);
+        it("calls ServiceRecordService.update and returns 200 + payload", async () => {
+                const spy = jest.spyOn(ServiceRecordService, "update").mockResolvedValue(returned as any);
 
-		const res = await request(app).put(`/api/v1/services/${recordId}`).set("Authorization", `Bearer ${token}`).send(updatePayload);
+                const res = await request(app)
+                        .put(`/api/v1/services/${recordId}`)
+                        .set("Authorization", `Bearer ${token}`)
+                        .send(updatePayload);
 
-		expect(spy).toHaveBeenCalledWith(recordId, userId, updatePayload);
-		expect(res.status).toBe(200);
-		expect(res.body).toEqual(returned);
-	});
+                expect(spy).toHaveBeenCalledWith(recordId, userId, expect.objectContaining(updatePayload));
+                expect(res.status).toBe(200);
+                expect(res.body).toEqual(returned);
+        });
 
 	it("returns 404 when ServiceRecordService.update throws 'Service record not found'", async () => {
 		jest.spyOn(ServiceRecordService, "update").mockRejectedValue(new Error("Service record not found"));

--- a/tests/ServiceRecordService.spec.ts
+++ b/tests/ServiceRecordService.spec.ts
@@ -2,19 +2,21 @@ import ServiceRecordService, { CreateServiceRecordDTO } from "../src/services/Se
 import ServiceRecord from "../src/models/ServiceRecord";
 
 describe("ServiceRecordService", () => {
-	const dto: CreateServiceRecordDTO = {
-		userId: "user1",
-		vehicleId: "veh1",
-		serviceType: "oil_filter",
-		itemName: "OEM",
-		cost: 50,
-		mileage: 12000,
-		date: new Date("2024-01-01"),
-		shop: "Home",
-		selfService: true,
-		note: "Changed oil filter",
-		photos: ["url1"],
-	};
+        const photoBuf = Buffer.from("img");
+        const base64Photo = photoBuf.toString("base64");
+        const dto: CreateServiceRecordDTO = {
+                userId: "user1",
+                vehicleId: "veh1",
+                serviceType: "oil_filter",
+                itemName: "OEM",
+                cost: 50,
+                mileage: 12000,
+                date: new Date("2024-01-01"),
+                shop: "Home",
+                selfService: true,
+                note: "Changed oil filter",
+                photos: [photoBuf],
+        };
 
 	afterEach(() => {
 		jest.restoreAllMocks();
@@ -28,24 +30,24 @@ describe("ServiceRecordService", () => {
 				return Promise.resolve(this);
 			});
 
-			const result = await ServiceRecordService.create(dto);
+                        const result = await ServiceRecordService.create(dto);
 
-			expect(saveSpy).toHaveBeenCalled();
-			expect(result).toMatchObject({
-				userId: dto.userId,
-				vehicleId: dto.vehicleId,
-				serviceType: dto.serviceType,
-				itemName: dto.itemName,
-				cost: dto.cost,
-				mileage: dto.mileage,
-				shop: dto.shop,
-				selfService: dto.selfService,
-				note: dto.note,
-				photos: dto.photos,
-				date: dto.date,
-				createdAt: now,
-			});
-		});
+                        expect(saveSpy).toHaveBeenCalled();
+                        expect(result).toMatchObject({
+                                userId: dto.userId,
+                                vehicleId: dto.vehicleId,
+                                serviceType: dto.serviceType,
+                                itemName: dto.itemName,
+                                cost: dto.cost,
+                                mileage: dto.mileage,
+                                shop: dto.shop,
+                                selfService: dto.selfService,
+                                note: dto.note,
+                                photos: [base64Photo],
+                                date: dto.date,
+                                createdAt: now,
+                        });
+                });
 
 		it("throws if save fails", async () => {
 			const err = new Error("DB failure");
@@ -57,13 +59,27 @@ describe("ServiceRecordService", () => {
 	describe("getById()", () => {
 		const id = "srv1";
 		it("returns payload when found", async () => {
-			const now = new Date();
-			const found = { ...dto, id, createdAt: now };
-			const spy = jest.spyOn(ServiceRecord, "findOne").mockResolvedValue(found as any);
-			const result = await ServiceRecordService.getById(id, dto.userId);
-			expect(spy).toHaveBeenCalledWith({ _id: id, userId: dto.userId });
-			expect(result).toEqual(found);
-		});
+                        const now = new Date();
+                        const found = { ...dto, id, createdAt: now };
+                        const spy = jest.spyOn(ServiceRecord, "findOne").mockResolvedValue(found as any);
+                        const result = await ServiceRecordService.getById(id, dto.userId);
+                        expect(spy).toHaveBeenCalledWith({ _id: id, userId: dto.userId });
+                        expect(result).toEqual({
+                                id,
+                                userId: dto.userId,
+                                vehicleId: dto.vehicleId,
+                                serviceType: dto.serviceType,
+                                itemName: dto.itemName,
+                                cost: dto.cost,
+                                mileage: dto.mileage,
+                                date: dto.date,
+                                shop: dto.shop,
+                                selfService: dto.selfService,
+                                note: dto.note,
+                                photos: [base64Photo],
+                                createdAt: now,
+                        });
+                });
 
 		it("returns null when not found", async () => {
 			jest.spyOn(ServiceRecord, "findOne").mockResolvedValue(null);
@@ -80,12 +96,28 @@ describe("ServiceRecordService", () => {
 
 	describe("list()", () => {
 		it("returns records for user", async () => {
-			const docs = [{ ...dto, id: "r1", createdAt: new Date() }];
-			const spy = jest.spyOn(ServiceRecord, "find").mockResolvedValue(docs as any);
-			const res = await ServiceRecordService.list(dto.userId);
-			expect(spy).toHaveBeenCalledWith({ userId: dto.userId });
-			expect(res).toEqual(docs);
-		});
+                        const docs = [{ ...dto, id: "r1", createdAt: new Date() }];
+                        const spy = jest.spyOn(ServiceRecord, "find").mockResolvedValue(docs as any);
+                        const res = await ServiceRecordService.list(dto.userId);
+                        expect(spy).toHaveBeenCalledWith({ userId: dto.userId });
+                        expect(res).toEqual([
+                                {
+                                        id: "r1",
+                                        userId: dto.userId,
+                                        vehicleId: dto.vehicleId,
+                                        serviceType: dto.serviceType,
+                                        itemName: dto.itemName,
+                                        cost: dto.cost,
+                                        mileage: dto.mileage,
+                                        shop: dto.shop,
+                                        selfService: dto.selfService,
+                                        note: dto.note,
+                                        photos: [base64Photo],
+                                        date: dto.date,
+                                        createdAt: docs[0].createdAt,
+                                },
+                        ]);
+                });
 
 		it("throws if find fails", async () => {
 			const err = new Error("DB failure");
@@ -100,13 +132,28 @@ describe("ServiceRecordService", () => {
 		const updatePayload = { note: "updated" };
 
 		it("updates and returns payload", async () => {
-			const now = new Date();
-			const updated = { ...dto, ...updatePayload, id, createdAt: now };
-			const spy = jest.spyOn(ServiceRecord, "findOneAndUpdate").mockResolvedValue(updated as any);
-			const result = await ServiceRecordService.update(id, userId, updatePayload);
-			expect(spy).toHaveBeenCalledWith({ _id: id, userId }, updatePayload, { new: true });
-			expect(result).toEqual(updated);
-		});
+                        const now = new Date();
+                        const updated = { ...dto, ...updatePayload, id, createdAt: now };
+                        const spy = jest.spyOn(ServiceRecord, "findOneAndUpdate").mockResolvedValue(updated as any);
+                        const result = await ServiceRecordService.update(id, userId, updatePayload);
+                        expect(spy).toHaveBeenCalledWith({ _id: id, userId }, updatePayload, { new: true });
+                        expect(result).toEqual({
+                                ...updatePayload,
+                                id,
+                                userId: dto.userId,
+                                vehicleId: dto.vehicleId,
+                                serviceType: dto.serviceType,
+                                itemName: dto.itemName,
+                                cost: dto.cost,
+                                mileage: dto.mileage,
+                                shop: dto.shop,
+                                selfService: dto.selfService,
+                                note: updatePayload.note,
+                                photos: [base64Photo],
+                                date: dto.date,
+                                createdAt: now,
+                        });
+                });
 
 		it("throws when not found", async () => {
 			jest.spyOn(ServiceRecord, "findOneAndUpdate").mockResolvedValue(null as any);

--- a/tests/ServiceRecordService.spec.ts
+++ b/tests/ServiceRecordService.spec.ts
@@ -1,0 +1,138 @@
+import ServiceRecordService, { CreateServiceRecordDTO } from "../src/services/ServiceRecordService";
+import ServiceRecord from "../src/models/ServiceRecord";
+
+describe("ServiceRecordService", () => {
+	const dto: CreateServiceRecordDTO = {
+		userId: "user1",
+		vehicleId: "veh1",
+		serviceType: "oil_filter",
+		itemName: "OEM",
+		cost: 50,
+		mileage: 12000,
+		date: new Date("2024-01-01"),
+		shop: "Home",
+		selfService: true,
+		note: "Changed oil filter",
+		photos: ["url1"],
+	};
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	describe("create()", () => {
+		it("saves a new record and returns payload", async () => {
+			const now = new Date();
+			const saveSpy = jest.spyOn(ServiceRecord.prototype, "save").mockImplementation(function (this: any) {
+				this.createdAt = now;
+				return Promise.resolve(this);
+			});
+
+			const result = await ServiceRecordService.create(dto);
+
+			expect(saveSpy).toHaveBeenCalled();
+			expect(result).toMatchObject({
+				userId: dto.userId,
+				vehicleId: dto.vehicleId,
+				serviceType: dto.serviceType,
+				itemName: dto.itemName,
+				cost: dto.cost,
+				mileage: dto.mileage,
+				shop: dto.shop,
+				selfService: dto.selfService,
+				note: dto.note,
+				photos: dto.photos,
+				date: dto.date,
+				createdAt: now,
+			});
+		});
+
+		it("throws if save fails", async () => {
+			const err = new Error("DB failure");
+			jest.spyOn(ServiceRecord.prototype, "save").mockRejectedValue(err);
+			await expect(ServiceRecordService.create(dto)).rejects.toThrow("DB failure");
+		});
+	});
+
+	describe("getById()", () => {
+		const id = "srv1";
+		it("returns payload when found", async () => {
+			const now = new Date();
+			const found = { ...dto, id, createdAt: now };
+			const spy = jest.spyOn(ServiceRecord, "findOne").mockResolvedValue(found as any);
+			const result = await ServiceRecordService.getById(id, dto.userId);
+			expect(spy).toHaveBeenCalledWith({ _id: id, userId: dto.userId });
+			expect(result).toEqual(found);
+		});
+
+		it("returns null when not found", async () => {
+			jest.spyOn(ServiceRecord, "findOne").mockResolvedValue(null);
+			const result = await ServiceRecordService.getById(id, dto.userId);
+			expect(result).toBeNull();
+		});
+
+		it("throws if lookup fails", async () => {
+			const err = new Error("DB failure");
+			jest.spyOn(ServiceRecord, "findOne").mockRejectedValue(err);
+			await expect(ServiceRecordService.getById(id, dto.userId)).rejects.toThrow("DB failure");
+		});
+	});
+
+	describe("list()", () => {
+		it("returns records for user", async () => {
+			const docs = [{ ...dto, id: "r1", createdAt: new Date() }];
+			const spy = jest.spyOn(ServiceRecord, "find").mockResolvedValue(docs as any);
+			const res = await ServiceRecordService.list(dto.userId);
+			expect(spy).toHaveBeenCalledWith({ userId: dto.userId });
+			expect(res).toEqual(docs);
+		});
+
+		it("throws if find fails", async () => {
+			const err = new Error("DB failure");
+			jest.spyOn(ServiceRecord, "find").mockRejectedValue(err);
+			await expect(ServiceRecordService.list(dto.userId)).rejects.toThrow("DB failure");
+		});
+	});
+
+	describe("update()", () => {
+		const id = "srv123";
+		const userId = dto.userId;
+		const updatePayload = { note: "updated" };
+
+		it("updates and returns payload", async () => {
+			const now = new Date();
+			const updated = { ...dto, ...updatePayload, id, createdAt: now };
+			const spy = jest.spyOn(ServiceRecord, "findOneAndUpdate").mockResolvedValue(updated as any);
+			const result = await ServiceRecordService.update(id, userId, updatePayload);
+			expect(spy).toHaveBeenCalledWith({ _id: id, userId }, updatePayload, { new: true });
+			expect(result).toEqual(updated);
+		});
+
+		it("throws when not found", async () => {
+			jest.spyOn(ServiceRecord, "findOneAndUpdate").mockResolvedValue(null as any);
+			await expect(ServiceRecordService.update(id, userId, updatePayload)).rejects.toThrow("Service record not found");
+		});
+	});
+
+	describe("remove()", () => {
+		const id = "srv123";
+		const userId = dto.userId;
+
+		it("deletes record", async () => {
+			const spy = jest.spyOn(ServiceRecord, "findOneAndDelete").mockResolvedValue({ id } as any);
+			await ServiceRecordService.remove(id, userId);
+			expect(spy).toHaveBeenCalledWith({ _id: id, userId });
+		});
+
+		it("throws if not found", async () => {
+			jest.spyOn(ServiceRecord, "findOneAndDelete").mockResolvedValue(null);
+			await expect(ServiceRecordService.remove(id, userId)).rejects.toThrow("Service record not found");
+		});
+
+		it("throws if delete fails", async () => {
+			const err = new Error("DB failure");
+			jest.spyOn(ServiceRecord, "findOneAndDelete").mockRejectedValue(err);
+			await expect(ServiceRecordService.remove(id, userId)).rejects.toThrow("DB failure");
+		});
+	});
+});

--- a/tests/ServiceRecordService.spec.ts
+++ b/tests/ServiceRecordService.spec.ts
@@ -2,8 +2,8 @@ import ServiceRecordService, { CreateServiceRecordDTO } from "../src/services/Se
 import ServiceRecord from "../src/models/ServiceRecord";
 
 describe("ServiceRecordService", () => {
-        const photoBuf = Buffer.from("img");
-        const base64Photo = photoBuf.toString("base64");
+        const photoName = "img.jpg";
+        const photoUrl = `/uploads/${photoName}`;
         const dto: CreateServiceRecordDTO = {
                 userId: "user1",
                 vehicleId: "veh1",
@@ -15,7 +15,7 @@ describe("ServiceRecordService", () => {
                 shop: "Home",
                 selfService: true,
                 note: "Changed oil filter",
-                photos: [photoBuf],
+                photos: [photoName],
         };
 
 	afterEach(() => {
@@ -43,7 +43,7 @@ describe("ServiceRecordService", () => {
                                 shop: dto.shop,
                                 selfService: dto.selfService,
                                 note: dto.note,
-                                photos: [base64Photo],
+                                photos: [photoUrl],
                                 date: dto.date,
                                 createdAt: now,
                         });
@@ -76,7 +76,7 @@ describe("ServiceRecordService", () => {
                                 shop: dto.shop,
                                 selfService: dto.selfService,
                                 note: dto.note,
-                                photos: [base64Photo],
+                                photos: [photoUrl],
                                 createdAt: now,
                         });
                 });
@@ -112,7 +112,7 @@ describe("ServiceRecordService", () => {
                                         shop: dto.shop,
                                         selfService: dto.selfService,
                                         note: dto.note,
-                                        photos: [base64Photo],
+                                        photos: [photoUrl],
                                         date: dto.date,
                                         createdAt: docs[0].createdAt,
                                 },
@@ -149,7 +149,7 @@ describe("ServiceRecordService", () => {
                                 shop: dto.shop,
                                 selfService: dto.selfService,
                                 note: updatePayload.note,
-                                photos: [base64Photo],
+                                photos: [photoUrl],
                                 date: dto.date,
                                 createdAt: now,
                         });


### PR DESCRIPTION
## Summary
- add CRUD API for vehicle service records
- document service record endpoints and schema
- cover service records with unit tests

## Testing
- `npm test --silent 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b32ab47198832596645820806c719b